### PR TITLE
Update Dockerfile

### DIFF
--- a/docker-tpl/Dockerfile
+++ b/docker-tpl/Dockerfile
@@ -33,10 +33,10 @@ USER dockerbot
 # Build tools are part of the builder image; project code is mounted
 RUN mkdir -p $HOME/.gradle/init.d/
 
-RUN wget https://services.gradle.org/distributions/gradle-6.0-bin.zip -P /tmp
+RUN wget https://services.gradle.org/distributions/gradle-7.3-bin.zip -P /tmp
 RUN unzip -d $HOME/gradle /tmp/gradle-*.zip
 
-ENV GRADLE_HOME=/home/dockerbot/gradle/gradle-6.0
+ENV GRADLE_HOME=/home/dockerbot/gradle/gradle-7.3
 ENV PATH=$GRADLE_HOME/bin:$PATH
 
 RUN echo "\


### PR DESCRIPTION
ghidra build failed in Ubuntu 18.04, suggesting minimum version of gradle 7.3 is needed.
Nevertheless ghidra build still failed even after this change due to problems associated with file formats in Build file '/files/ghidra/build.gradle' line: 242